### PR TITLE
set first sig by arrayData

### DIFF
--- a/src/models/transaction.js
+++ b/src/models/transaction.js
@@ -83,7 +83,9 @@ transaction.advancedTransfer = function(guid, transaction, password, arrayData) 
       .signTransaction(guid, JSON.stringify(transaction), password)
       .then(ret => {
         let signatures = ret.signatures
-        signatures[0] = arrayData
+        if (arrayData && arrayData.length > 0) {
+          signatures[0] = arrayData
+        }
         bytom.transaction
           .submitPayment(guid, ret.raw_transaction, signatures)
           .then(res3 => {


### PR DESCRIPTION
If an advanced transaction haven't any args, it is a normal transaction. The signatures should be the original signatures after signing the raw transaction. Usually, it is used for a lock asset smart contract transaction.

If an advanced transaction do have args to commit. the first signatures will be replaced by the arguments data. Usually,  it is used for  an unlock asset smart contract transaction.